### PR TITLE
This udev rule allows the 720IT to be used immediately after being plugged in

### DIFF
--- a/lib/udev/rules.d/69-libomron.rules
+++ b/lib/udev/rules.d/69-libomron.rules
@@ -1,0 +1,8 @@
+ACTION!="add|change", GOTO="mm_libomron_end"
+SUBSYSTEM!="usb", GOTO="mm_libomron_end"
+ENV{DEVTYPE}!="usb_device", GOTO="mm_libomron_end"
+
+# Omron Corp. HP-720IT Pedometer / Blood Pressure Monitor HEM-7080IT-E
+ATTRS{idVendor}=="0590", ATTRS{idProduct}=="0028", ENV{ID_MM_LIBOMRON}="1", SYMLINK+="libomron-%k", MODE="0664", GROUP="plugdev"
+
+LABEL="mm_libomron_end"


### PR DESCRIPTION
Tested on an account in plugdev group. Immediately after plugging in device, omron_720IT_test works without any manual configuration, and this handy symlink is created:

$ ls -Ll /dev/libomron-*
crw-rw-r-T 1 root plugdev 189, 134 Oct 26 17:06 /dev/libomron-2-1
